### PR TITLE
Add a "Streams is" statement to main page.

### DIFF
--- a/_includes/streamsIs.html
+++ b/_includes/streamsIs.html
@@ -12,4 +12,26 @@ The new Java Application API allows you to write applications in Java alone.
 </div>
 </section>
 
+<section id="StreamsIsnorow">
+<div class="container">
+<div class="col-lg-12 text-center">
+<h2 class="section-heading">Building Applications With Streams</h2>
+</div>
+Streams is a platform for distributed, efficient, fault-tolerant, real-time computation.  Applications can be written in 
+SPL, a langauge developed specifically for streaming.  SPL allows you to build your own operators using either C++ or Java.
+The new Java Application API allows you to write applications in Java alone.  
+</div>
+</section>
+
+<section id="StreamsIsv2">
+<div class="container">
+<div class="row">
+<div class="col-lg-12 text-center">
+<h3 class="section-heading">Streams is a platform for distributed, efficient, fault-tolerant, real-time computation. </h3>
+</div>
+<!-- text would go here, if I had any -->
+</div>
+</div>
+</section>
+
 

--- a/_includes/streamsIs.html
+++ b/_includes/streamsIs.html
@@ -22,5 +22,5 @@ The new Java Application API allows you to write applications in Java alone.
 -->
 
 <div class="text-center">
-  <h3>  Streams is a platform for distributed, efficient, fault-tolerant, real-time computation.  </h3>
+  <h3>  <i>Streams is a platform for distributed, efficient, fault-tolerant, real-time computation.</i>  </h3>
 </div>

--- a/_includes/streamsIs.html
+++ b/_includes/streamsIs.html
@@ -22,5 +22,5 @@ The new Java Application API allows you to write applications in Java alone.
 -->
 
 <div class="text-center">
-  <h3>  <i>Streams is a platform for distributed, efficient, fault-tolerant, real-time computation.</i>  </h3>
+  <h3>Streams is a platform for distributed, efficient, fault-tolerant, real-time computation. </h3>
 </div>

--- a/_includes/streamsIs.html
+++ b/_includes/streamsIs.html
@@ -7,32 +7,6 @@
 </div>
 Streams allows you to compose applications from simple functional units.
 </div>
-<div class="row text-center">
-<div class="col-md-4">
-<span class="fa-stack fa-4x">
-<i class="fa fa-circle fa-stack-2x text-primary"></i>
-<a href="http://ibmstreams.github.io/streamsx.topology/" class="fa fa-fire fa-stack-1x fa-inverse icon" ></a>
-</span>
-<h4 class="service-heading"><a href="http://ibmstreams.github.io/streamsx.topology/" class="blackLink">Java Application API</a></h4>
-<p class="text-muted">Write Streams applications in Java using the new Java Application API.</p>
-</div>
-<div class="col-md-4">
-<span class="fa-stack fa-4x">
-<i class="fa fa-circle fa-stack-2x text-primary"></i>
-<a href="http://ibmstreams.github.io/streamsx.sparkMLLib/" class="fa fa-bar-chart-o fa-stack-1x fa-inverse icon"></a>
-</span>
-<h4 class="service-heading"><a href="http://ibmstreams.github.io/streamsx.sparkMLLib/" class="blackLink">Spark MLlib Toolkit</a></h4>
-<p class="text-muted">Leverage real-time machine learning using Apache Spark's machine learning library on Streams.</p>
-</div>
-<div class="col-md-4">
-<span class="fa-stack fa-4x">
-<i class="fa fa-circle fa-stack-2x text-primary"></i>
-<a href="http://ibmstreams.github.io/resourceManagers/" class="fa fa-cubes fa-stack-1x fa-inverse icon"></a>
-</span>
-<h4 class="service-heading"><a href="http://ibmstreams.github.io/resourceManagers/" class="blackLink">Yarn Resource Manager</a></h4>
-<p class="text-muted">Use the Streams extensible resource management framework to run Streams on your Yarn cluster.</p>
-</div>
-</div>
 </div>
 </section>
 

--- a/_includes/streamsIs.html
+++ b/_includes/streamsIs.html
@@ -1,0 +1,38 @@
+<!-- Streams Is sEction -->
+<section id="StreamsIs">
+<div class="container">
+<div class="row">
+<div class="col-lg-12 text-center">
+<h2 class="section-heading">What's New</h2>
+</div>
+</div>
+<div class="row text-center">
+<div class="col-md-4">
+<span class="fa-stack fa-4x">
+<i class="fa fa-circle fa-stack-2x text-primary"></i>
+<a href="http://ibmstreams.github.io/streamsx.topology/" class="fa fa-fire fa-stack-1x fa-inverse icon" ></a>
+</span>
+<h4 class="service-heading"><a href="http://ibmstreams.github.io/streamsx.topology/" class="blackLink">Java Application API</a></h4>
+<p class="text-muted">Write Streams applications in Java using the new Java Application API.</p>
+</div>
+<div class="col-md-4">
+<span class="fa-stack fa-4x">
+<i class="fa fa-circle fa-stack-2x text-primary"></i>
+<a href="http://ibmstreams.github.io/streamsx.sparkMLLib/" class="fa fa-bar-chart-o fa-stack-1x fa-inverse icon"></a>
+</span>
+<h4 class="service-heading"><a href="http://ibmstreams.github.io/streamsx.sparkMLLib/" class="blackLink">Spark MLlib Toolkit</a></h4>
+<p class="text-muted">Leverage real-time machine learning using Apache Spark's machine learning library on Streams.</p>
+</div>
+<div class="col-md-4">
+<span class="fa-stack fa-4x">
+<i class="fa fa-circle fa-stack-2x text-primary"></i>
+<a href="http://ibmstreams.github.io/resourceManagers/" class="fa fa-cubes fa-stack-1x fa-inverse icon"></a>
+</span>
+<h4 class="service-heading"><a href="http://ibmstreams.github.io/resourceManagers/" class="blackLink">Yarn Resource Manager</a></h4>
+<p class="text-muted">Use the Streams extensible resource management framework to run Streams on your Yarn cluster.</p>
+</div>
+</div>
+</div>
+</section>
+
+

--- a/_includes/streamsIs.html
+++ b/_includes/streamsIs.html
@@ -3,7 +3,7 @@
 <div class="container">
 <div class="row">
 <div class="col-lg-12 text-center">
-<h2 class="section-heading">What's New</h2>
+<h2 class="section-heading">Streams Is</h2>
 </div>
 </div>
 <div class="row text-center">

--- a/_includes/streamsIs.html
+++ b/_includes/streamsIs.html
@@ -1,4 +1,5 @@
 <!-- Streams Is Section -->
+<!--  I think the idea is to keep this page detail free, so maybe just stick to a single-sentence streams description.
 <section id="StreamsIs">
 <div class="container">
 <div class="row">
@@ -11,6 +12,7 @@ The new Java Application API allows you to write applications in Java alone.
 </div>
 </div>
 </section>
+-->
 
 <section id="StreamsIsv2">
 <div class="col-lg-12 text-center">

--- a/_includes/streamsIs.html
+++ b/_includes/streamsIs.html
@@ -3,8 +3,9 @@
 <div class="container">
 <div class="row">
 <div class="col-lg-12 text-center">
-<h2 class="section-heading">Streams Is</h2>
+<h2 class="section-heading">Streams is a platform for distributed, fault-tolerant, real-time computation.</h2>
 </div>
+Streams allows you to compose applications from simple functional units.
 </div>
 <div class="row text-center">
 <div class="col-md-4">

--- a/_includes/streamsIs.html
+++ b/_includes/streamsIs.html
@@ -3,9 +3,11 @@
 <div class="container">
 <div class="row">
 <div class="col-lg-12 text-center">
-<h2 class="section-heading">Streams is a platform for distributed, fault-tolerant, real-time computation.</h2>
+<h2 class="section-heading">Building Applications With Streams</h2>
 </div>
-Streams allows you to compose applications from simple functional units.
+Streams is a platform for distributed, efficient, fault-tolerant, real-time computation.  Applications can be written in 
+SPL, a langauge developed specifically for streaming.  SPL allows you to build your own operators using either C++ or Java.
+The new Java Application API allows you to write applications in Java alone.  
 </div>
 </div>
 </section>

--- a/_includes/streamsIs.html
+++ b/_includes/streamsIs.html
@@ -1,4 +1,4 @@
-<!-- Streams Is sEction -->
+<!-- Streams Is Section -->
 <section id="StreamsIs">
 <div class="container">
 <div class="row">
@@ -12,25 +12,9 @@ The new Java Application API allows you to write applications in Java alone.
 </div>
 </section>
 
-<section id="StreamsIsnorow">
-<div class="container">
-<div class="col-lg-12 text-center">
-<h2 class="section-heading">Building Applications With Streams</h2>
-</div>
-Streams is a platform for distributed, efficient, fault-tolerant, real-time computation.  Applications can be written in 
-SPL, a langauge developed specifically for streaming.  SPL allows you to build your own operators using either C++ or Java.
-The new Java Application API allows you to write applications in Java alone.  
-</div>
-</section>
-
 <section id="StreamsIsv2">
-<div class="container">
-<div class="row">
 <div class="col-lg-12 text-center">
 <h3 class="section-heading">Streams is a platform for distributed, efficient, fault-tolerant, real-time computation. </h3>
-</div>
-<!-- text would go here, if I had any -->
-</div>
 </div>
 </section>
 

--- a/_includes/streamsIs.html
+++ b/_includes/streamsIs.html
@@ -13,11 +13,14 @@ The new Java Application API allows you to write applications in Java alone.
 </div>
 </section>
 -->
-
+<!--  too much white space!
 <section id="StreamsIsv2">
 <div class="col-lg-12 text-center">
 <h3 class="section-heading">Streams is a platform for distributed, efficient, fault-tolerant, real-time computation. </h3>
 </div>
 </section>
+-->
 
-
+<div class="text-center">
+  <h3>  Streams is a platform for distributed, efficient, fault-tolerant, real-time computation.  </h3>
+</div>

--- a/_includes/streamsIs.html
+++ b/_includes/streamsIs.html
@@ -1,18 +1,4 @@
 <!-- Streams Is Section -->
-<!--  I think the idea is to keep this page detail free, so maybe just stick to a single-sentence streams description.
-<section id="StreamsIs">
-<div class="container">
-<div class="row">
-<div class="col-lg-12 text-center">
-<h2 class="section-heading">Building Applications With Streams</h2>
-</div>
-Streams is a platform for distributed, efficient, fault-tolerant, real-time computation.  Applications can be written in 
-SPL, a langauge developed specifically for streaming.  SPL allows you to build your own operators using either C++ or Java.
-The new Java Application API allows you to write applications in Java alone.  
-</div>
-</div>
-</section>
--->
 <!--  too much white space!
 <section id="StreamsIsv2">
 <div class="col-lg-12 text-center">

--- a/_includes/whatsNew.html
+++ b/_includes/whatsNew.html
@@ -2,7 +2,7 @@
     <section id="WhatsNew">
         <div class="container">
             <div class="row">
-                <h3> test text</h3>
+                <h3> Streams is a platform for distributed, efficient, fault-tolerant, real-time computation. </h3>
                 <div class="col-lg-12 text-center">
                     <h2 class="section-heading">What's New</h2>
                 </div>

--- a/_includes/whatsNew.html
+++ b/_includes/whatsNew.html
@@ -1,5 +1,7 @@
 <!-- What's New Section -->
+    <h3> here </h3>
     <section id="WhatsNew">
+        <h3> ipso factum </h3>
         <div class="container">
             <h3> Streams is a platform for distributed, efficient, fault-tolerant, real-time computation. </h3>
             <div class="row">

--- a/_includes/whatsNew.html
+++ b/_includes/whatsNew.html
@@ -1,7 +1,9 @@
 <!-- What's New Section -->
-    <h3> here </h3>
+   <div class="text-center">
+    <h3>  Streams is a platform for distributed, efficient, fault-tolerant, real-time computation.  </h3>
+    </div>
     <section id="WhatsNew">
-        <h3> ipso factum </h3>
+        <h3> some text</h3>
         <div class="container">
             <h3> Streams is a platform for distributed, efficient, fault-tolerant, real-time computation. </h3>
             <div class="row">

--- a/_includes/whatsNew.html
+++ b/_includes/whatsNew.html
@@ -1,8 +1,8 @@
 <!-- What's New Section -->
     <section id="WhatsNew">
         <div class="container">
+            <h3> Streams is a platform for distributed, efficient, fault-tolerant, real-time computation. </h3>
             <div class="row">
-                <h3> Streams is a platform for distributed, efficient, fault-tolerant, real-time computation. </h3>
                 <div class="col-lg-12 text-center">
                     <h2 class="section-heading">What's New</h2>
                 </div>

--- a/_includes/whatsNew.html
+++ b/_includes/whatsNew.html
@@ -2,6 +2,7 @@
     <section id="WhatsNew">
         <div class="container">
             <div class="row">
+                <h3> test text</h3>
                 <div class="col-lg-12 text-center">
                     <h2 class="section-heading">What's New</h2>
                 </div>

--- a/_includes/whatsNew.html
+++ b/_includes/whatsNew.html
@@ -1,11 +1,6 @@
 <!-- What's New Section -->
-   <div class="text-center">
-    <h3>  Streams is a platform for distributed, efficient, fault-tolerant, real-time computation.  </h3>
-    </div>
     <section id="WhatsNew">
-        <h3> some text</h3>
         <div class="container">
-            <h3> Streams is a platform for distributed, efficient, fault-tolerant, real-time computation. </h3>
             <div class="row">
                 <div class="col-lg-12 text-center">
                     <h2 class="section-heading">What's New</h2>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,7 +7,6 @@
     <body id="page-top" class="index">
 
     {% include header.html %}
-    {% include streamsIs.html %}
     {% include whatsNew.html %}
     {% include portfolio_grid.html %}
     {% include explore.html %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,6 +7,7 @@
     <body id="page-top" class="index">
 
     {% include header.html %}
+    {% include streamsIs.html %}
     {% include whatsNew.html %}
     {% include portfolio_grid.html %}
     {% include explore.html %}


### PR DESCRIPTION
A statement describing what Streams does would help people who are new to Streams.
That was part of the [feedback on the Java Application/Topology API](https://github.com/IBMStreams/streamsx.topology/issues/38), but I think it also applies to the project as a whole.  

So I added one sentence to the web page between the top graphic and the what's new section.  
You can preview here: http://hildrum.github.io/

I tried a few different ways of laying it out (below I have a snapshot where the sentence is in italics), and the one currently there is what I liked best.

Here's the italics version:
<img width="1226" alt="screen shot 2015-07-15 at 5 40 31 pm" src="https://cloud.githubusercontent.com/assets/5419652/8710695/c10f5590-2b19-11e5-8c76-011333f83714.png">
