### PR TITLE
Streaming Analytics text link does not work under what's new

### DIFF
--- a/_includes/whatsNew.html
+++ b/_includes/whatsNew.html
@@ -28,7 +28,7 @@
                         <i class="fa fa-circle fa-stack-2x text-primary"></i>
                         <a href="#cloud" data-toggle="modal" class="fa fa-cloud fa-stack-1x fa-inverse icon"></a>
                     </span>
-                    <h4 class="service-heading"><a href="#cloud" class="blackLink">Streaming Analytics<br><br></a></h4>
+                    <h4 class="service-heading"><a href="#cloud" data-toggle="modal" class="blackLink">Streaming Analytics<br><br></a></h4>
                     <p class="text-muted">Perform real-time analysis on data in motion on the cloud with IBM Streaming Analytics for Bluemix™.</p>
                 </div>
             </div>


### PR DESCRIPTION
Missing data-toggle property on link.
